### PR TITLE
feat(phones): admin seed/update/delete  et user claim/release numbers

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoggerModule } from 'nestjs-pino';
 import { AuthModule } from './auth/auth.module';
 import { OffersModule } from './offers/offers.module';
+import { PhonesModule } from './phones/phones.module';
 
 
 
@@ -32,7 +33,8 @@ import { OffersModule } from './offers/offers.module';
     ConfigModule.forRoot(),
     UsersModule,
     AuthModule,
-    OffersModule,],
+    OffersModule,
+    PhonesModule,],
   controllers: [],
   providers: [],
 })

--- a/src/offers/offers.service.ts
+++ b/src/offers/offers.service.ts
@@ -1,8 +1,8 @@
 import {
-  Injectable,
-  ForbiddenException,
-  NotFoundException,
-  ConflictException,
+    Injectable,
+    ForbiddenException,
+    NotFoundException,
+    ConflictException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { addDays } from 'date-fns';
@@ -14,116 +14,165 @@ import { SubscribeDto } from './dto/subscribe.dto';
 
 @Injectable()
 export class OffersService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly logger: Logger,    
-  ) {}
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly logger: Logger,
+    ) { }
 
-  /*  ADMIN */
- 
-  async createOffer(dto: CreateOfferDto) {
-    try {
-      const offer = await this.prisma.offer.create({ data: dto });
-      this.logger.log({ id: offer.id }, 'Offer created');
-      return offer;
-    } catch (err) {
-      if ((err as Prisma.PrismaClientKnownRequestError).code === 'P2002') {
-        throw new ConflictException('Offer with same name already exists');
-      }
-      this.logger.error(err, 'Failed to create offer');
-      throw err;
+    /*  ADMIN */
+
+    async createOffer(dto: CreateOfferDto) {
+        try {
+            const offer = await this.prisma.offer.create({ data: dto });
+            this.logger.log({ id: offer.id }, 'Offer created');
+            return offer;
+        } catch (err) {
+            if ((err as Prisma.PrismaClientKnownRequestError).code === 'P2002') {
+                throw new ConflictException('Offer with same name already exists');
+            }
+            this.logger.error(err, 'Failed to create offer');
+            throw err;
+        }
     }
-  }
 
-  async updateOffer(id: string, dto: UpdateOfferDto) {
-    try {
-      const offer = await this.prisma.offer.update({
-        where: { id },
-        data: dto,
-      });
-      this.logger.log({ id }, 'Offer updated');
-      return offer;
-    } catch (err) {
-      if (this.isNotFound(err)) throw new NotFoundException('Offer not found');
-      this.logger.error(err, 'Failed to update offer');
-      throw err;
+    async updateOffer(id: string, dto: UpdateOfferDto) {
+        try {
+            const offer = await this.prisma.offer.update({
+                where: { id },
+                data: dto,
+            });
+            this.logger.log({ id }, 'Offer updated');
+            return offer;
+        } catch (err) {
+            if (this.isNotFound(err)) throw new NotFoundException('Offer not found');
+            this.logger.error(err, 'Failed to update offer');
+            throw err;
+        }
     }
-  }
 
-  async removeOffer(id: string) {
-    try {
-      await this.prisma.offer.delete({ where: { id } });
-      this.logger.log({ id }, 'Offer deleted');
-    } catch (err) {
-      if (this.isNotFound(err)) throw new NotFoundException('Offer not found');
-      this.logger.error(err, 'Failed to delete offer');
-      throw err;
+    async removeOffer(id: string) {
+        try {
+            await this.prisma.offer.delete({ where: { id } });
+            this.logger.log({ id }, 'Offer deleted');
+        } catch (err) {
+            if (this.isNotFound(err)) throw new NotFoundException('Offer not found');
+            this.logger.error(err, 'Failed to delete offer');
+            throw err;
+        }
     }
-  }
 
- 
-  //  PUBLIC 
-  
-  async findAllOffer() {
-    return this.prisma.offer.findMany({ orderBy: { price: 'asc' } });
-  }
 
- //USER : souscription*/
- 
-  async subscribeToOffer(userId: string, offerId: string, dto: SubscribeDto) {
-    try {
-      const [wallet, offer] = await Promise.all([
-        this.prisma.wallet.findUnique({ where: { userId } }),
-        this.prisma.offer.findUnique({ where: { id: offerId } }),
-      ]);
+    //  PUBLIC 
 
-      if (!offer) throw new NotFoundException('Offer not found');
-      if (!wallet || wallet.balance < offer.price)
-        throw new ForbiddenException('Solde insuffisant');
-
-      await this.prisma.$transaction([
-        this.prisma.wallet.update({
-          where: { id: wallet.id },
-          data: { balance: { decrement: offer.price } },
-        }),
-        this.prisma.subscription.create({
-          data: {
-            phoneId: dto.phoneId,
-            offerId,
-            startDate: new Date(),
-            endDate: addDays(new Date(), offer.validityDays),
-            remaining: offer.quotaAmount,
-          },
-        }),
-        this.prisma.invoice.create({
-          data: {
-            userId,
-            amount: offer.price,
-            month: new Date(),
-          },
-        }),
-      ]);
-
-      this.logger.log(
-        { userId, offerId },
-        'User subscribed successfully to offer',
-      );
-    } catch (err) {
-      this.logger.error(
-        { userId, offerId, err },
-        'Subscription transaction failed',
-      );
-      throw err;
+    async findAllOffer() {
+        return this.prisma.offer.findMany({ orderBy: { price: 'asc' } });
     }
-  }
 
-  
-  //  Helpers 
+    //USER : souscription*/
+    /**
+      * Souscrit l'utilisateur à une offre et renvoie la subscription créée + nouveau solde.
+      * @throws NotFoundException  si l'offre n'existe pas
+      * @throws ForbiddenException si solde insuffisant ou numéro non autorisé
+      * @throws ConflictException  si une souscription active existe déjà
+      */
+    async subscribeToOffer(
+        userId: string,
+        offerId: string,
+        dto: SubscribeDto,
+    ) {
+        try {
+            /* Vérifs préalables */
+            const [wallet, offer, phone] = await Promise.all([
+                this.prisma.wallet.findUnique({ where: { userId } }),
+                this.prisma.offer.findUnique({ where: { id: offerId } }),
+                this.prisma.phoneNumber.findUnique({ where: { id: dto.phoneId } }),
+            ]);
+            console.log('balance:', wallet?.balance)
+            console.log('prix:', offer?.price)
+            if (!offer) throw new NotFoundException('Offre introuvable');
+            if (!wallet || (Number(wallet.balance) < Number(offer.price)))
+                throw new ForbiddenException('Solde insuffisant');
+            if (!phone || phone.userId !== userId)
+                throw new ForbiddenException('Numéro non autorisé');
 
-  private isNotFound(err: unknown) {
-    return (
-      (err as Prisma.PrismaClientKnownRequestError).code === 'P2025' ||
-      err instanceof NotFoundException
-    );
-  }
+            // Empêche une double souscription active
+            const activeCount = await this.prisma.subscription.count({
+                where: {
+                    phoneId: dto.phoneId,
+                    offerId,
+                    status: 'ACTIVE',
+                },
+            });
+            if (activeCount)
+                throw new ConflictException(
+                    'Souscription déjà active pour ce numéro',
+                );
+
+            /*  Transaction */
+            const { updatedWallet, subscription } =
+                await this.prisma.$transaction(async (tx) => {
+                    const updatedWallet = await tx.wallet.update({
+                        where: { id: wallet.id },
+                        data: { balance: { decrement: offer.price } },
+                    });
+
+                    // Création de la souscription
+                    const subscription = await tx.subscription.create({
+                        data: {
+                            phoneId: dto.phoneId,
+                            offerId,
+                            startDate: new Date(),
+                            endDate: addDays(new Date(), offer.validityDays),
+                            remaining: offer.quotaAmount,
+                            status: 'ACTIVE',
+                        },
+                        include: { offer: true },
+                    });
+
+                    //Facture liée
+                    await tx.invoice.create({
+                        data: {
+                            userId,
+                            amount: offer.price,
+                            month: new Date(),
+                            subscriptionId: subscription.id,
+                        },
+                    });
+
+                    return { updatedWallet, subscription };
+                });
+
+            this.logger.log(
+                { userId, offerId, subscriptionId: subscription.id },
+                'Souscription réussie',
+            );
+
+            return {
+                message: `Souscription confirmée ! Nouveau solde : ${updatedWallet.balance.toFixed(2)} $`,
+                subscription: {
+                    id: subscription.id,
+                    phoneId: subscription.phoneId,
+                    offer: subscription.offer.name,
+                    startDate: subscription.startDate,
+                    endDate: subscription.endDate,
+                    remaining: subscription.remaining,
+                },
+                walletBalance: Number(updatedWallet.balance),
+            };
+        } catch (err) {
+            this.logger.error(
+                { userId, offerId, err },
+                'Échec de la souscription',
+            );
+            throw err;
+        }
+    }
+
+    //  Helpers 
+    private isNotFound(err: unknown) {
+        return (
+            (err as Prisma.PrismaClientKnownRequestError).code === 'P2025' ||
+            err instanceof NotFoundException
+        );
+    }
 }

--- a/src/phones/admin.controller.ts
+++ b/src/phones/admin.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Delete, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth-guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/roles.decorator';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { CreatePhoneDto } from './dto/create-phone.dto';
+import { PhonesService } from './phones.service';
+import { UpdatePhoneStatusDto } from './dto/update-phone-status.dto';
+
+@ApiTags('admin/phones')
+@ApiBearerAuth('Authorization')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+@Controller('admin/phones')
+export class PhonesAdminController {
+    constructor(private readonly phones: PhonesService) { }
+
+    @ApiOperation({ summary: 'Approvisionner le pool de numéros' })
+    @ApiResponse({
+        status: 201,
+        description: 'Nombre de numéros créés',
+        schema: { example: { count: 50 } },
+    })
+    @Post()
+    create(@Body() dto: CreatePhoneDto | CreatePhoneDto[]) {
+        const list = Array.isArray(dto) ? dto : [dto];
+        return this.phones.createManyNumber(list);
+    }
+
+
+
+    @ApiOperation({ summary: 'Changer le statut d’un numéro' })
+    @ApiParam({ name: 'id', description: 'ID du numéro' })
+    @ApiResponse({ status: 200, description: 'Statut mis à jour' })
+    @Patch(':id')
+    updateStatus(@Param('id') id: string, @Body() dto: UpdatePhoneStatusDto) {
+        return this.phones.updateStatus(id, dto);
+    }
+
+
+
+    @ApiOperation({ summary: 'Supprimer un numéro UNASSIGNED' })
+    @ApiParam({ name: 'id', description: 'ID du numéro' })
+    @ApiResponse({ status: 200, description: 'Numéro supprimé' })
+    @ApiResponse({ status: 403, description: 'Numéro utilisé ou inexistant' })
+    @Delete(':id')
+    remove(@Param('id') id: string) {
+        return this.phones.remove(id);
+    }
+}

--- a/src/phones/dto/create-phone.dto.ts
+++ b/src/phones/dto/create-phone.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreatePhoneDto {
+  @ApiProperty({ example: '243970000123' })
+  @IsString()
+  msisdn: string;
+
+  @ApiProperty({ example: '6300100000123' })
+  @IsString()
+  imsi: string;
+}

--- a/src/phones/dto/update-phone-status.dto.ts
+++ b/src/phones/dto/update-phone-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { PhoneStatus } from '@prisma/client';
+
+export class UpdatePhoneStatusDto {
+  @ApiProperty({ enum: PhoneStatus, example: 'SUSPENDED' })
+  @IsEnum(PhoneStatus)
+  status: PhoneStatus;
+}

--- a/src/phones/phones.controller.ts
+++ b/src/phones/phones.controller.ts
@@ -1,0 +1,65 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Param,
+    UseGuards,
+    Delete,
+} from '@nestjs/common';
+import { CurrentUser } from 'src/auth/current-user-decorator';
+import { PhonesService } from './phones.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth-guard';
+import { TokenPayload } from 'src/auth/token-payload-interface';
+import { ApiBearerAuth, ApiOperation, ApiTags, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('phones')
+@ApiBearerAuth('Authorization')
+@UseGuards(JwtAuthGuard)
+@Controller('phones')
+export class PhonesController {
+    constructor(private readonly phones: PhonesService) { }
+
+    @ApiOperation({ summary: 'Lister les numéros disponibles' })
+    @ApiResponse({ status: 200, description: 'Liste des numéros disponibles' })
+    @ApiResponse({ status: 401, description: 'JWT manquant ou invalide' })
+    @ApiResponse({ status: 403, description: 'Accès refusé' })
+    @Get('available')
+    list() {
+        return this.phones.findAvailableNumber();
+    }
+
+
+    @ApiOperation({ summary: 'Réserver un numéro et recevoir 50 $' })
+    @ApiParam({ name: 'id', description: 'ID du numéro' })
+    @ApiResponse({
+        status: 201,
+        description: 'Numéro réservé, bonus crédité',
+        schema: { example: { phoneId: '...', bonus: 50 } },
+    })
+    @ApiResponse({ status: 403, description: 'Numéro indisponible' })
+    @Post(':id/claim')
+    claim(
+        @CurrentUser() user: TokenPayload,
+        @Param('id') phoneId: string,
+    ) {
+        return this.phones.claimNumber(user.userId, phoneId);
+    }
+
+
+    
+    @ApiOperation({ summary: 'Abandonner / libérer son numéro' })
+    @ApiParam({ name: 'id', description: 'ID du numéro' })
+    @ApiResponse({
+        status: 200,
+        description: 'Numéro libéré',
+        schema: { example: { phoneId: '...', status: 'UNASSIGNED' } },
+    })
+    @ApiResponse({ status: 403, description: 'Numéro non lié ou abonnement actif' })
+    @Delete(':id/release')
+    release(
+        @CurrentUser() user: TokenPayload,
+        @Param('id') phoneId: string,
+    ) {
+        return this.phones.release(user.userId, phoneId);
+    }
+}

--- a/src/phones/phones.module.ts
+++ b/src/phones/phones.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PhonesService } from './phones.service';
+import { PhonesController } from './phones.controller';
+import { PhonesAdminController } from './admin.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [PhonesService],
+  controllers: [PhonesController, PhonesAdminController]
+})
+export class PhonesModule {}

--- a/src/phones/phones.service.ts
+++ b/src/phones/phones.service.ts
@@ -1,0 +1,108 @@
+import {
+    Injectable,
+    ForbiddenException,
+    NotFoundException,
+    ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Logger } from 'nestjs-pino';
+import { CreatePhoneDto } from './dto/create-phone.dto';
+import { Prisma } from '@prisma/client';
+import { UpdatePhoneStatusDto } from './dto/update-phone-status.dto';
+
+@Injectable()
+export class PhonesService {
+    constructor(private prisma: PrismaService, private logger: Logger) { }
+
+    // ADMIN
+    async createManyNumber(list: CreatePhoneDto[]) {
+        try {
+            const result = await this.prisma.phoneNumber.createMany({ data: list });
+            this.logger.log({ count: result.count }, 'Phones seeded');
+            return result;
+        } catch (err) {
+            if ((err as Prisma.PrismaClientKnownRequestError).code === 'P2002') {
+                throw new ConflictException('Duplicate MSISDN or IMSI');
+            }
+            throw err;
+        }
+    }
+
+    async updateStatus(id: string, dto: UpdatePhoneStatusDto) {
+        return this.prisma.phoneNumber.update({
+            where: { id },
+            data: { status: dto.status },
+        });
+    }
+
+    async remove(id: string) {
+        const phone = await this.prisma.phoneNumber.findUnique({ where: { id } });
+        if (!phone || phone.status !== 'UNASSIGNED')
+            throw new ForbiddenException('Numéro utilisé ou inexistant');
+        return this.prisma.phoneNumber.delete({ where: { id } });
+    }
+
+    // USER
+
+    findAvailableNumber() {
+        return this.prisma.phoneNumber.findMany({
+            where: { status: 'UNASSIGNED' },
+            select: { id: true, msisdn: true },
+            orderBy: { msisdn: 'asc' },
+        });
+    }
+
+    async claimNumber(userId: string, phoneId: string) {
+        return this.prisma.$transaction(async (tx) => {
+            const phone = await tx.phoneNumber.findFirst({
+                where: { id: phoneId, status: 'UNASSIGNED' },
+            });
+            if (!phone) throw new ForbiddenException('Numéro indisponible');
+
+            // assignation
+            await tx.phoneNumber.update({
+                where: { id: phoneId },
+                data: { userId, status: 'ACTIVE' },
+            });
+
+            const user = await tx.user.findUnique({ where: { id: userId } });
+
+            let bonus = 0;
+            if (user?.isNew) {
+                bonus = 50;
+                await Promise.all([
+                    tx.wallet.update({
+                        where: { userId },
+                        data: { balance: { increment: bonus } },
+                    }),
+                    tx.user.update({
+                        where: { id: userId },
+                        data: { isNew: false, topUpCumulative: { increment: bonus } },
+                    }),
+                ]);
+            }
+
+            this.logger.log({ userId, phoneId, bonus }, 'Phone claimed');
+            return { phoneId, bonus };
+        });
+    }
+
+
+    async release(userId: string, phoneId: string) {
+        const phone = await this.prisma.phoneNumber.findUnique({ where: { id: phoneId } });
+        if (!phone || phone.userId !== userId)
+            throw new ForbiddenException('Numéro non attribué à cet utilisateur');
+
+        // Vérifier qu'il n'y a pas d'abonnements actifs
+        const activeSubs = await this.prisma.subscription.count({
+            where: { phoneId, status: 'ACTIVE' },
+        });
+        if (activeSubs > 0)
+            throw new ForbiddenException(`Abonnement actif, résiliez-le d'abord`);
+
+        return this.prisma.phoneNumber.update({
+            where: { id: phoneId },
+            data: { status: 'UNASSIGNED', userId: null },
+        }); 
+    }
+}


### PR DESCRIPTION
Ajoute la gestion complète des numéros :

Admin : seed / mise à jour du statut / suppression d’un numéro (/admin/phones).
User : liste des numéros libres, réservation avec bonus +50 $, libération d’un numéro (/phones).
Transactions Prisma sécurisées, création automatique du wallet, logs Pino et docs Swagger.